### PR TITLE
Extend README, remove duplicate const, lower feature level

### DIFF
--- a/DXUtil.h
+++ b/DXUtil.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <memory>
+#include <string>
+#include "atlstr.h"
 
 // Helper for deleting directX objects (see DXObj below)
 template<typename DXType>
@@ -16,3 +18,16 @@ struct DXReleaseHelper
 // This is similar to CComPointer but safer, lower overhead, and more standardized
 template<typename DXType>
 using DXObj = std::unique_ptr<DXType, DXReleaseHelper<DXType>>;
+
+
+std::string HResultToString(HRESULT hr) {
+	LPWSTR output;
+	if (FAILED(hr)) {
+		FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
+			FORMAT_MESSAGE_ALLOCATE_BUFFER |
+			FORMAT_MESSAGE_IGNORE_INSERTS, NULL, hr,
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+			(LPTSTR)&output, 0, NULL);
+	}
+	return CW2A(output);
+}

--- a/DirectX11Example.cpp
+++ b/DirectX11Example.cpp
@@ -149,7 +149,7 @@ HWND InitWindow(HINSTANCE hInstance, int nCmdShow)
 
 DXObj<ID3D11Device> CreateDevice(DXObj<ID3D11DeviceContext>& deviceContext)
 {
-	D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_1;
+	D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
 	ID3D11Device* deviceCPtr = nullptr;
 	ID3D11DeviceContext* deviceContextCPtr = nullptr;
 	const HRESULT err = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0/*D3D11_CREATE_DEVICE_DEBUG*/, &featureLevel, 1, D3D11_SDK_VERSION, &deviceCPtr, nullptr, &deviceContextCPtr);

--- a/DirectX11Example.cpp
+++ b/DirectX11Example.cpp
@@ -156,7 +156,7 @@ DXObj<ID3D11Device> CreateDevice(DXObj<ID3D11DeviceContext>& deviceContext)
 	DXObj<ID3D11Device> device(deviceCPtr);
 	deviceContext.reset(deviceContextCPtr);
 	if (FAILED(err) || !device || !deviceContext)
-		throw runtime_error("Unable to create device");
+		throw runtime_error("Unable to create device. " + HResultToString(err));
 	return device;
 }
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ More features are planned in the future, including Eye Tracking.
 To build and run, follow these steps:
 
 1. Ensure CMake (https://cmake.org/) and Visual Studio 2015 or later are installed.
-2. Run CMake to generate a 64-bit Visual Studio project.
-3. Open the generated Visual Studio project, and build and run from there.
+2. Ensure that the folder containing FoveClient.dll is added to the PATH environment variable.
+3. Run CMake to generate a 64 bit Visual Studio project.
+4. Open the generated Visual Studio project.
+5. Ensure that the selected target is x64 (and the linker options do not contain /machine:X86).
+6. Build and run.
 
 If you run into any difficulties, hit us up on the forums. http://forum.getfove.com/
 

--- a/Util.cpp
+++ b/Util.cpp
@@ -45,7 +45,7 @@ Fove::SFVR_Matrix44 QuatToMatrix(const Fove::SFVR_Quaternion q)
 	return ret;
 }
 
-Fove::SFVR_Matrix44 Transpose(const const Fove::SFVR_Matrix44& m)
+Fove::SFVR_Matrix44 Transpose(const Fove::SFVR_Matrix44& m)
 {
 	Fove::SFVR_Matrix44 ret;
 	ret.mat[0][0] = m.mat[0][0]; ret.mat[0][1] = m.mat[1][0]; ret.mat[0][2] = m.mat[2][0]; ret.mat[0][3] = m.mat[3][0];


### PR DESCRIPTION
- extended the README based on the problems I had
- added helper function for better error reporting
- removed duplicate `const` qualifier from a function argument
- lowered feature level to `D3D_FEATURE_LEVEL_11_0` (couldn't get `D3D_FEATURE_LEVEL_11_1` to work, even though I have the latest Windows SDK)